### PR TITLE
Corrige data utilizada pelo template de issues durante a criação do arquivo `.id`

### DIFF
--- a/templates/issue_db_entry.txt
+++ b/templates/issue_db_entry.txt
@@ -46,8 +46,8 @@
 % if ctrl_vocabulary is not UNDEFINED and ctrl_vocabulary:
 !v085!${ctrl_vocabulary}
 % endif
-% if created is not UNDEFINED and created:
-!v091!${created}
+% if updated is not UNDEFINED and updated:
+!v091!${updated}
 % endif
 % if editorial_standard is not UNDEFINED and editorial_standard:
 !v117!${editorial_standard}


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige o template utilizado para gerar arquivos `id`. O campo `v91` deve utilizar a data de `atualização` e não a data de criação.

#### Onde a revisão poderia começar?
- `templates/issue_db_entry.txt`

#### Como este poderia ser testado manualmente?

Não há um modo fácil de testar este PR sem alterar/criar dados em um scielo manager de homolog.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
